### PR TITLE
fix: moves from private to public onfinality rpc endpoint

### DIFF
--- a/src/light-node/config.yml
+++ b/src/light-node/config.yml
@@ -5,7 +5,7 @@ bootstraps = [
 full_node_ws = [
     "wss://mainnet.avail-rpc.com",
     "wss://avail-mainnet.public.blastapi.io",
-    "wss://avail.api.onfinality.io/ws?apikey=13f13c3f-28e8-4120-bf7f-12fd20686907",
+    "wss://avail.api.onfinality.io/public-ws",
     "wss://avail-us.brightlystake.com",
     "wss://avail-rpc.publicnode.com"
 ]


### PR DESCRIPTION
# Changes
- [x] Moves from private to public onfinality rpc endpoint

## Reason for change
Private endpoint was decommissioned and public one should be used instead.