### PR TITLE
feat: Adds extra bootnode

### DIFF
--- a/src/light-node/config.yml
+++ b/src/light-node/config.yml
@@ -1,6 +1,7 @@
 project_name = "sophon"
 bootstraps = [
-    "/dns/bootnode.1.lightclient.mainnet.avail.so/tcp/37000/p2p/12D3KooW9x9qnoXhkHAjdNFu92kMvBRSiFBMAoC5NnifgzXjsuiM"
+    "/dns/bootnode.1.lightclient.mainnet.avail.so/tcp/37000/p2p/12D3KooW9x9qnoXhkHAjdNFu92kMvBRSiFBMAoC5NnifgzXjsuiM",
+    "/dns/bootnode.2.lightclient.mainnet.avail.so/tcp/37000/p2p/12D3KooWSPvXWWGvL5jLQrDRDfvw1yHHuu4VyUjBN5uPjtaZjTJB"
 ]
 full_node_ws = [
     "wss://mainnet.avail-rpc.com",


### PR DESCRIPTION
# Change
- [x] Adds extra bootnode


## Reason for change
Over the next weeks we're expecting a surge in total LC count. 
An extra bootnode helps bootstrap p2p network on LC, which ease the load to fetch cells from RPC, in favor of p2p network.
This change will improve on overall network reliability.